### PR TITLE
Add apply methods for typed ActorTestKit allowing (#27338)

### DIFF
--- a/akka-actor-testkit-typed/src/main/mima-filters/2.6.4.backwards.excludes/27338-ActorTestKit-system.excludes
+++ b/akka-actor-testkit-typed/src/main/mima-filters/2.6.4.backwards.excludes/27338-ActorTestKit-system.excludes
@@ -1,0 +1,3 @@
+# #27338 allow passing ActorSystem to ActorTestKit
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.testkit.typed.scaladsl.ActorTestKit.internalSystem")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.actor.testkit.typed.scaladsl.ActorTestKit.this")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -38,8 +38,8 @@ object ActorTestKit {
   /**
    * Create a testkit from the provided actor system.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] based on the provided actor system,
-   * e.g. threads will include the name of the related actor system.
+   * It will use the provided [[akka.actor.typed.ActorSystem]] and create a ActorTestKit,
+   * e.g. threads will include the name of the provided actor system.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -6,7 +6,6 @@ package akka.actor.testkit.typed.javadsl
 
 import java.time.Duration
 
-import akka.actor.setup.ActorSystemSetup
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -50,21 +49,6 @@ object ActorTestKit {
    */
   def create(system: ActorSystem[_]): ActorTestKit =
     new ActorTestKit(scaladsl.ActorTestKit(system))
-
-  /**
-   * Create a testkit from the provided name and actor system setup.
-   *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name and actor system setup,
-   * e.g. threads will include the name and related actor system setup.
-   * When the test has completed you should terminate the `ActorSystem` and
-   * the testkit with [[ActorTestKit#shutdownTestKit]].
-   *
-   * Config loaded from `application-test.conf` if that exists, otherwise
-   * using default configuration from the reference.conf resources that ship with the Akka libraries.
-   * The application.conf of your project is not used in this case.
-   */
-  def create(name: String, actorSystemSetup: ActorSystemSetup): ActorTestKit =
-    new ActorTestKit(scaladsl.ActorTestKit(TestKitUtils.scrubActorSystemName(name), actorSystemSetup))
 
   /**
    * Create a named testkit.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -39,8 +39,8 @@ object ActorTestKit {
   /**
    * Create a testkit from the provided actor system.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with the provided actor name,
-   * e.g. threads will include the provided actor name.
+   * It will create an [[akka.actor.typed.ActorSystem]] based on the provided actor system,
+   * e.g. threads will include the name of the related actor system.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -55,7 +55,7 @@ object ActorTestKit {
    * Create a testkit from the provided name and actor system setup.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name and actor system setup,
-   * e.g. threads will include the name.
+   * e.g. threads will include the name and related actor system setup.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -21,10 +21,8 @@ import akka.util.JavaDurationConverters._
 object ActorTestKit {
 
   /**
-   * Create a testkit named from the class that is calling this method.
+   * Create a testkit named from the ActorTestKit class.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
-   * e.g. threads will include the name.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -38,20 +36,17 @@ object ActorTestKit {
   /**
    * Create a testkit from the provided actor system.
    *
-   * It will use the provided [[akka.actor.typed.ActorSystem]] and create a ActorTestKit,
-   * e.g. threads will include the name of the provided actor system.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
-   * Config loaded from `application-test.conf` if that exists, otherwise
+   * Config loaded from the provided actor if that exists, otherwise
    * using default configuration from the reference.conf resources that ship with the Akka libraries.
-   * The application.conf of your project is not used in this case.
    */
   def create(system: ActorSystem[_]): ActorTestKit =
     new ActorTestKit(scaladsl.ActorTestKit(system))
 
   /**
-   * Create a named testkit.
+   * Create a testkit using the provided name.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
@@ -66,11 +61,11 @@ object ActorTestKit {
     new ActorTestKit(scaladsl.ActorTestKit(name))
 
   /**
-   * Create a testkit named from the class that is calling this method,
+   * Create a testkit named from the ActorTestKit class,
    * and use a custom config for the actor system.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
-   * e.g. threads will include the name.
+   * It will also used the provided customConfig provided to create the `ActorSystem`
+   *
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    */
@@ -78,10 +73,14 @@ object ActorTestKit {
     new ActorTestKit(scaladsl.ActorTestKit(TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]), customConfig))
 
   /**
-   * Create a named testkit, and use a custom config for the actor system.
+   * Create a test kit named based on the provided name,
+   * and uses the provided custom config for the actor system.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
+   *
+   * It will also used the provided customConfig provided to create the `ActorSystem`
+   *
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    */
@@ -89,11 +88,14 @@ object ActorTestKit {
     new ActorTestKit(scaladsl.ActorTestKit(name, customConfig))
 
   /**
-   * Create a named testkit, and use a custom config for the actor system,
-   * and a custom [[akka.actor.testkit.typed.TestKitSettings]]
+   * Create an [[akka.actor.typed.ActorSystem]] named based on the provided name,
+   * use the provided custom config for the actor system, and the testkit will use the provided setting.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
+   *
+   * It will also used the provided customConfig provided to create the `ActorSystem`, and provided setting.
+   *
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    */

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -38,10 +38,10 @@ object ActorTestKit {
 
 
   /**
-   * Create a testkit named from the class that is calling this method.
+   * Create a testkit from the provided actor system.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
-   * e.g. threads will include the name.
+   * It will create an [[akka.actor.typed.ActorSystem]] with the provided actor name,
+   * e.g. threads will include the provided actor name.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -53,9 +53,9 @@ object ActorTestKit {
     new ActorTestKit(scaladsl.ActorTestKit(system))
 
   /**
-   * Create a testkit named from the class that is calling this method.
+   * Create a testkit from the provided name and actor system setup.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
+   * It will create an [[akka.actor.typed.ActorSystem]] with this name and actor system setup,
    * e.g. threads will include the name.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -6,6 +6,7 @@ package akka.actor.testkit.typed.javadsl
 
 import java.time.Duration
 
+import akka.actor.setup.ActorSystemSetup
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -34,6 +35,37 @@ object ActorTestKit {
    */
   def create(): ActorTestKit =
     new ActorTestKit(scaladsl.ActorTestKit(TestKitUtils.testNameFromCallStack(classOf[ActorTestKit])))
+
+
+  /**
+   * Create a testkit named from the class that is calling this method.
+   *
+   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
+   * e.g. threads will include the name.
+   * When the test has completed you should terminate the `ActorSystem` and
+   * the testkit with [[ActorTestKit#shutdownTestKit]].
+   *
+   * Config loaded from `application-test.conf` if that exists, otherwise
+   * using default configuration from the reference.conf resources that ship with the Akka libraries.
+   * The application.conf of your project is not used in this case.
+   */
+  def create(system: ActorSystem[_]): ActorTestKit =
+    new ActorTestKit(scaladsl.ActorTestKit(system))
+
+  /**
+   * Create a testkit named from the class that is calling this method.
+   *
+   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
+   * e.g. threads will include the name.
+   * When the test has completed you should terminate the `ActorSystem` and
+   * the testkit with [[ActorTestKit#shutdownTestKit]].
+   *
+   * Config loaded from `application-test.conf` if that exists, otherwise
+   * using default configuration from the reference.conf resources that ship with the Akka libraries.
+   * The application.conf of your project is not used in this case.
+   */
+  def create(name: String, actorSystemSetup: ActorSystemSetup): ActorTestKit =
+    new ActorTestKit(scaladsl.ActorTestKit(TestKitUtils.scrubActorSystemName(name), actorSystemSetup))
 
   /**
    * Create a named testkit.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -36,7 +36,6 @@ object ActorTestKit {
   def create(): ActorTestKit =
     new ActorTestKit(scaladsl.ActorTestKit(TestKitUtils.testNameFromCallStack(classOf[ActorTestKit])))
 
-
   /**
    * Create a testkit from the provided actor system.
    *

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
@@ -55,6 +55,11 @@ final class TestKitJunitResource(_kit: ActorTestKit) extends ExternalResource {
   def this() = this(ActorTestKit.create(TestKitUtils.testNameFromCallStack(classOf[TestKitJunitResource])))
 
   /**
+   * Use a custom [[akka.actor.typed.ActorSystem]] for the actor system.
+   */
+  def this(system: ActorSystem[_]) = this(ActorTestKit.create(system))
+
+  /**
    * Use a custom config for the actor system.
    */
   def this(customConfig: String) =

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -26,10 +26,8 @@ import org.slf4j.LoggerFactory
 object ActorTestKit {
 
   /**
-   * Create an [[akka.actor.typed.ActorSystem]] named from the ActorTestKit class.
+   * Create a testkit named from the ActorTestKit class.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with the name ActorTestKit,
-   * e.g. threads will include the name ActorTestKit.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -48,8 +46,6 @@ object ActorTestKit {
   /**
    * Create a testkit from the provided actor system.
    *
-   * It will use the provided [[akka.actor.typed.ActorSystem]] and create a ActorTestKit,
-   * e.g. threads will include the name of the provided actor system.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -62,7 +58,7 @@ object ActorTestKit {
   }
 
   /**
-   * Create an [[akka.actor.typed.ActorSystem]] using the provided name.
+   * Create a testkit using the provided name.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
@@ -80,11 +76,8 @@ object ActorTestKit {
   }
 
   /**
-   * Create an [[akka.actor.typed.ActorSystem]] named from the ActorTestKit class,
+   * Create a testkit named from the ActorTestKit class,
    * and use a custom config for the actor system.
-   *
-   * It will create an [[akka.actor.typed.ActorSystem]] with the name ActorTestKit,
-   * e.g. threads will include the name.
    *
    * It will also used the provided customConfig provided to create the `ActorSystem`
    *
@@ -100,7 +93,7 @@ object ActorTestKit {
   }
 
   /**
-   * Create an [[akka.actor.typed.ActorSystem]] named based on the provided name,
+   * Create a test kit named based on the provided name,
    * and uses the provided custom config for the actor system.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -48,8 +48,8 @@ object ActorTestKit {
   /**
    * Create a testkit named based on the provided ActorSystem.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] based on the provided actor system,
-   * e.g. threads will include the name, and the related actor system setup.
+   * It will use the provided [[akka.actor.typed.ActorSystem]] and create a ActorTestKit,
+   * e.g. threads will include the name of the provided actor system.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -39,7 +39,10 @@ object ActorTestKit {
    */
   def apply(): ActorTestKit =
     new ActorTestKit(
-      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]), ApplicationTestConfig),
+      ActorSystem(
+        ActorTestKitGuardian.testKitGuardian,
+        TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
+        ApplicationTestConfig),
       settings = None)
 
   /**
@@ -84,7 +87,10 @@ object ActorTestKit {
    */
   def apply(customConfig: Config): ActorTestKit =
     new ActorTestKit(
-      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]), customConfig),
+      ActorSystem(
+        ActorTestKitGuardian.testKitGuardian,
+        TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
+        customConfig),
       settings = None)
 
   /**
@@ -149,9 +155,7 @@ object ActorTestKit {
  *
  * For synchronous testing of a `Behavior` see [[BehaviorTestKit]]
  */
-final class ActorTestKit private[akka] (
-    val internalSystem: ActorSystem[_],
-    settings: Option[TestKitSettings]) {
+final class ActorTestKit private[akka] (val internalSystem: ActorSystem[_], settings: Option[TestKitSettings]) {
 
   // avoid slf4j noise by touching it first from single thread #28673
   LoggerFactory.getLogger(internalSystem.name).debug("Starting ActorTestKit")
@@ -192,7 +196,9 @@ final class ActorTestKit private[akka] (
    * guardian
    */
   def spawn[T](behavior: Behavior[T], props: Props): ActorRef[T] =
-    Await.result(internalTestKitGuardian.ask(ActorTestKitGuardian.SpawnActorAnonymous(behavior, _, props)), timeout.duration)
+    Await.result(
+      internalTestKitGuardian.ask(ActorTestKitGuardian.SpawnActorAnonymous(behavior, _, props)),
+      timeout.duration)
 
   /**
    * Spawn the given behavior. This is created as a child of the test kit
@@ -206,7 +212,9 @@ final class ActorTestKit private[akka] (
    * guardian
    */
   def spawn[T](behavior: Behavior[T], name: String, props: Props): ActorRef[T] =
-    Await.result(internalTestKitGuardian.ask(ActorTestKitGuardian.SpawnActor(name, behavior, _, props)), timeout.duration)
+    Await.result(
+      internalTestKitGuardian.ask(ActorTestKitGuardian.SpawnActor(name, behavior, _, props)),
+      timeout.duration)
 
   /**
    * Stop the actor under test and wait until it terminates.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -168,6 +168,10 @@ final class ActorTestKit private[akka] (
     internalTestKitGuardian: ActorRef[ActorTestKitGuardian.TestKitCommand],
     settings: Option[TestKitSettings]) {
 
+  val name = internalSystem.name
+
+  val config = internalSystem.settings.config
+
   // avoid slf4j noise by touching it first from single thread #28673
   LoggerFactory.getLogger(internalSystem.name).debug("Starting ActorTestKit")
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -26,10 +26,10 @@ import org.slf4j.LoggerFactory
 object ActorTestKit {
 
   /**
-   * Create a testkit named from the class that is calling this method.
+   * Create an [[akka.actor.typed.ActorSystem]] named from the ActorTestKit class.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
-   * e.g. threads will include the name.
+   * It will create an [[akka.actor.typed.ActorSystem]] with the name ActorTestKit,
+   * e.g. threads will include the name ActorTestKit.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -37,13 +37,13 @@ object ActorTestKit {
    * using default configuration from the reference.conf resources that ship with the Akka libraries.
    * The application.conf of your project is not used in this case.
    */
-  def apply(): ActorTestKit =
-    new ActorTestKit(
-      ActorSystem(
-        ActorTestKitGuardian.testKitGuardian,
-        TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
-        ApplicationTestConfig),
-      settings = None)
+  def apply(): ActorTestKit = {
+    val system = ActorSystem(
+      ActorTestKitGuardian.testKitGuardian,
+      TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
+      ApplicationTestConfig)
+    new ActorTestKit(system, system, settings = None)
+  }
 
   /**
    * Create a testkit from the provided actor system.
@@ -53,14 +53,16 @@ object ActorTestKit {
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
-   * Config loaded from `system.settings.config` if that exists, otherwise
+   * Config loaded from the provided actor if that exists, otherwise
    * using default configuration from the reference.conf resources that ship with the Akka libraries.
    */
-  def apply(system: ActorSystem[_]): ActorTestKit =
-    new ActorTestKit(system, settings = None)
+  def apply(system: ActorSystem[_]): ActorTestKit = {
+    val testKitGuardian = system.systemActorOf(ActorTestKitGuardian.testKitGuardian, "test")
+    new ActorTestKit(system, testKitGuardian, settings = None)
+  }
 
   /**
-   * Create a named testkit.
+   * Create an [[akka.actor.typed.ActorSystem]] using the provided name.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
@@ -71,54 +73,67 @@ object ActorTestKit {
    * using default configuration from the reference.conf resources that ship with the Akka libraries.
    * The application.conf of your project is not used in this case.
    */
-  def apply(name: String): ActorTestKit =
-    new ActorTestKit(
-      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.scrubActorSystemName(name), ApplicationTestConfig),
-      settings = None)
+  def apply(name: String): ActorTestKit = {
+    val system =
+      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.scrubActorSystemName(name), ApplicationTestConfig)
+    new ActorTestKit(system, system, settings = None)
+  }
 
   /**
-   * Create a testkit named from the class that is calling this method,
+   * Create an [[akka.actor.typed.ActorSystem]] named from the ActorTestKit class,
    * and use a custom config for the actor system.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
+   * It will create an [[akka.actor.typed.ActorSystem]] with the name ActorTestKit,
    * e.g. threads will include the name.
+   *
+   * It will also used the provided customConfig provided to create the `ActorSystem`
+   *
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    */
-  def apply(customConfig: Config): ActorTestKit =
-    new ActorTestKit(
-      ActorSystem(
-        ActorTestKitGuardian.testKitGuardian,
-        TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
-        customConfig),
-      settings = None)
+  def apply(customConfig: Config): ActorTestKit = {
+    val system = ActorSystem(
+      ActorTestKitGuardian.testKitGuardian,
+      TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
+      customConfig)
+    new ActorTestKit(system, system, settings = None)
+  }
 
   /**
-   * Create a named testkit, and use a custom config for the actor system.
+   * Create an [[akka.actor.typed.ActorSystem]] named based on the provided name,
+   * and uses the provided custom config for the actor system.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
+   *
+   * It will also used the provided customConfig provided to create the `ActorSystem`
+   *
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    */
-  def apply(name: String, customConfig: Config): ActorTestKit =
-    new ActorTestKit(
-      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.scrubActorSystemName(name), customConfig),
-      settings = None)
+  def apply(name: String, customConfig: Config): ActorTestKit = {
+    val system =
+      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.scrubActorSystemName(name), customConfig)
+    new ActorTestKit(system, system, settings = None)
+  }
 
   /**
-   * Create a named testkit, and use a custom config for the actor system,
-   * and a custom [[akka.actor.testkit.typed.TestKitSettings]]
+   * Create an [[akka.actor.typed.ActorSystem]] named based on the provided name,
+   * use the provided custom config for the actor system, and the testkit will use the provided setting.
    *
    * It will create an [[akka.actor.typed.ActorSystem]] with this name,
    * e.g. threads will include the name.
+   *
+   * It will also used the provided customConfig provided to create the `ActorSystem`, and provided setting.
+   *
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    */
-  def apply(name: String, customConfig: Config, settings: TestKitSettings): ActorTestKit =
-    new ActorTestKit(
-      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.scrubActorSystemName(name), customConfig),
-      settings = Some(settings))
+  def apply(name: String, customConfig: Config, settings: TestKitSettings): ActorTestKit = {
+    val system =
+      ActorSystem(ActorTestKitGuardian.testKitGuardian, TestKitUtils.scrubActorSystemName(name), customConfig)
+    new ActorTestKit(system, system, settings = Some(settings))
+  }
 
   /**
    * Shutdown the given [[akka.actor.typed.ActorSystem]] and block until it shuts down,
@@ -155,7 +170,10 @@ object ActorTestKit {
  *
  * For synchronous testing of a `Behavior` see [[BehaviorTestKit]]
  */
-final class ActorTestKit private[akka] (val internalSystem: ActorSystem[_], settings: Option[TestKitSettings]) {
+final class ActorTestKit private[akka] (
+    val internalSystem: ActorSystem[_],
+    internalTestKitGuardian: ActorRef[ActorTestKitGuardian.TestKitCommand],
+    settings: Option[TestKitSettings]) {
 
   // avoid slf4j noise by touching it first from single thread #28673
   LoggerFactory.getLogger(internalSystem.name).debug("Starting ActorTestKit")
@@ -166,9 +184,6 @@ final class ActorTestKit private[akka] (val internalSystem: ActorSystem[_], sett
   /**
    * INTERNAL API
    */
-  @InternalApi private[akka] val internalTestKitGuardian: ActorRef[ActorTestKitGuardian.TestKitCommand] =
-    internalSystem.systemActorOf(ActorTestKitGuardian.testKitGuardian, "test")
-
   implicit def system: ActorSystem[Nothing] = internalSystem
 
   private val childName: Iterator[String] = Iterator.from(0).map(_.toString)

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -46,7 +46,7 @@ object ActorTestKit {
       settings = None)
 
   /**
-   * Create a testkit named based on the provided ActorSystem.
+   * Create a testkit from the provided actor system.
    *
    * It will use the provided [[akka.actor.typed.ActorSystem]] and create a ActorTestKit,
    * e.g. threads will include the name of the provided actor system.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -43,14 +43,14 @@ object ActorTestKit {
   def apply(): ActorTestKit =
     new ActorTestKit(
       name = TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
-      ActorSystemSetup.create(BootstrapSetup(ApplicationTestConfig)),
+      ActorSystemSetup.apply(BootstrapSetup(ApplicationTestConfig)),
       settings = None)
 
   /**
    * Create a testkit named based on the provided ActorSystem.
    *
-   * It will create an [[akka.actor.typed.ActorSystem]] with this name,
-   * e.g. threads will include the name, and the related actor sustem setup.
+   * It will create an [[akka.actor.typed.ActorSystem]] based on the provided actor system,
+   * e.g. threads will include the name, and the related actor system setup.
    * When the test has completed you should terminate the `ActorSystem` and
    * the testkit with [[ActorTestKit#shutdownTestKit]].
    *
@@ -60,7 +60,7 @@ object ActorTestKit {
   def apply(system: ActorSystem[_]): ActorTestKit = {
     new ActorTestKit(
       name = TestKitUtils.scrubActorSystemName(system.name),
-      ActorSystemSetup.create(BootstrapSetup(system.settings.config)),
+      ActorSystemSetup.apply(BootstrapSetup(system.settings.config)),
       settings = None)
   }
 
@@ -94,7 +94,7 @@ object ActorTestKit {
   def apply(name: String): ActorTestKit =
     new ActorTestKit(
       name = TestKitUtils.scrubActorSystemName(name),
-      ActorSystemSetup.create(BootstrapSetup(ApplicationTestConfig)),
+      ActorSystemSetup.apply(BootstrapSetup(ApplicationTestConfig)),
       settings = None)
 
   /**
@@ -109,7 +109,7 @@ object ActorTestKit {
   def apply(customConfig: Config): ActorTestKit =
     new ActorTestKit(
       name = TestKitUtils.testNameFromCallStack(classOf[ActorTestKit]),
-      ActorSystemSetup.create(BootstrapSetup(customConfig)),
+      ActorSystemSetup.apply(BootstrapSetup(customConfig)),
       settings = None)
 
   /**
@@ -123,7 +123,7 @@ object ActorTestKit {
   def apply(name: String, customConfig: Config): ActorTestKit =
     new ActorTestKit(
       name = TestKitUtils.scrubActorSystemName(name),
-      ActorSystemSetup.create(BootstrapSetup(customConfig)),
+      ActorSystemSetup.apply(BootstrapSetup(customConfig)),
       settings = None)
 
   /**
@@ -138,7 +138,7 @@ object ActorTestKit {
   def apply(name: String, customConfig: Config, settings: TestKitSettings): ActorTestKit =
     new ActorTestKit(
       name = TestKitUtils.scrubActorSystemName(name),
-      ActorSystemSetup.create(BootstrapSetup(customConfig)),
+      ActorSystemSetup.apply(BootstrapSetup(customConfig)),
       settings = Some(settings))
 
   /**
@@ -177,8 +177,8 @@ object ActorTestKit {
  * For synchronous testing of a `Behavior` see [[BehaviorTestKit]]
  */
 final class ActorTestKit private[akka] (
-    val name: String,
-    val systemSetup: ActorSystemSetup,
+    name: String,
+    systemSetup: ActorSystemSetup,
     settings: Option[TestKitSettings]) {
 
   // avoid slf4j noise by touching it first from single thread #28673

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
@@ -5,6 +5,7 @@
 package akka.actor.testkit.typed.scaladsl
 
 import akka.actor.testkit.typed.TestKitSettings
+import akka.actor.typed.ActorSystem
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ BeforeAndAfterAll, TestSuite }
@@ -40,6 +41,11 @@ abstract class ScalaTestWithActorTestKit(testKit: ActorTestKit)
    * The application.conf of your project is not used in this case.
    */
   def this() = this(ActorTestKit(ActorTestKitBase.testNameFromCallStack()))
+
+  /**
+   * Use a custom [[akka.actor.typed.ActorSystem]] for the actor system.
+   */
+  def this(system: ActorSystem[_]) = this(ActorTestKit(system))
 
   /**
    * Use a custom config for the actor system.

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -15,7 +15,7 @@ import akka.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
+import org.scalatest.wordspec.{ AnyWordSpec, AnyWordSpecLike }
 
 class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -23,7 +23,7 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
       system.name should ===("ActorTestKitSpec")
     }
 
-    "generate a test kit from the provided actor" in {
+    "generate a test kit from the provided actor system" in {
       val config = ConfigFactory.parseString("test.specific-config = yes")
       val system = ActorSystem(ActorTestKitGuardian.testKitGuardian, "TestActor", config)
       val testkit2 = ActorTestKit(system)

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -5,13 +5,17 @@
 package akka.actor.testkit.typed.scaladsl
 
 import akka.Done
-import scala.concurrent.Promise
+import akka.actor.BootstrapSetup
+import akka.actor.setup.ActorSystemSetup
+import akka.actor.testkit.typed.internal.ActorTestKitGuardian
+import akka.actor.typed.ActorSystem
 
+import scala.concurrent.Promise
 import akka.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.{ AnyWordSpec, AnyWordSpecLike }
+import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
 
 class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
@@ -19,6 +23,25 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
 
     "generate a default name from the test class via ScalaTestWithActorTestKit" in {
       system.name should ===("ActorTestKitSpec")
+    }
+
+    "generate a default name & ActorSystemSetup from the provided actor" in {
+      val config = ConfigFactory.parseString("test.specific-config = yes")
+      val system = ActorSystem(ActorTestKitGuardian.testKitGuardian, "TestActor", config)
+      val testkit2 = ActorTestKit(system)
+      try {
+        testkit2.system.name should ===("TestActor")
+        testkit2.system.settings.config.getString("test.specific-config") should ===("yes")
+      } finally testkit2.shutdownTestKit()
+    }
+
+    "generate a default name and load the ActorSystemSetup from the provided ActorSystemSetup" in {
+      val actorSystemSetup = ActorSystemSetup(BootstrapSetup(ConfigFactory.parseString("test.specific-config = yes")))
+      val testkit2 = ActorTestKit("TestActor", actorSystemSetup)
+      try {
+        testkit2.system.name should ===("TestActor")
+        testkit2.system.settings.config.getString("test.specific-config") should ===("yes")
+      } finally testkit2.shutdownTestKit()
     }
 
     "generate a default name from the test class" in {
@@ -64,23 +87,18 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
     }
 
     "load application-test.conf by default" in {
-      testKit.config.getString("test.from-application-test") should ===("yes")
       testKit.system.settings.config.getString("test.from-application-test") should ===("yes")
       testKit.system.settings.config.hasPath("test.from-application") should ===(false)
     }
 
     "not load application-test.conf if specific Config given" in {
       val testKit2 = ActorTestKit(ConfigFactory.parseString("test.specific-config = yes"))
-      testKit2.config.getString("test.specific-config") should ===("yes")
       testKit2.system.settings.config.getString("test.specific-config") should ===("yes")
-      testKit2.config.hasPath("test.from-application-test") should ===(false)
       testKit2.system.settings.config.hasPath("test.from-application-test") should ===(false)
       testKit2.system.settings.config.hasPath("test.from-application") should ===(false)
 
       // same if via ScalaTestWithActorTestKit
       val scalaTestWithActorTestKit2 = new ScalaTestWithActorTestKit("test.specific-config = yes") {}
-      scalaTestWithActorTestKit2.testKit.config.getString("test.specific-config") should ===("yes")
-      scalaTestWithActorTestKit2.testKit.config.hasPath("test.from-application-test") should ===(false)
       scalaTestWithActorTestKit2.system.settings.config.hasPath("test.from-application-test") should ===(false)
       scalaTestWithActorTestKit2.testKit.system.settings.config.hasPath("test.from-application") should ===(false)
     }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -5,8 +5,6 @@
 package akka.actor.testkit.typed.scaladsl
 
 import akka.Done
-import akka.actor.BootstrapSetup
-import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.internal.ActorTestKitGuardian
 import akka.actor.typed.ActorSystem
 
@@ -29,15 +27,6 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
       val config = ConfigFactory.parseString("test.specific-config = yes")
       val system = ActorSystem(ActorTestKitGuardian.testKitGuardian, "TestActor", config)
       val testkit2 = ActorTestKit(system)
-      try {
-        testkit2.system.name should ===("TestActor")
-        testkit2.system.settings.config.getString("test.specific-config") should ===("yes")
-      } finally testkit2.shutdownTestKit()
-    }
-
-    "generate a default name and load the ActorSystemSetup from the provided ActorSystemSetup" in {
-      val actorSystemSetup = ActorSystemSetup(BootstrapSetup(ConfigFactory.parseString("test.specific-config = yes")))
-      val testkit2 = ActorTestKit("TestActor", actorSystemSetup)
       try {
         testkit2.system.name should ===("TestActor")
         testkit2.system.settings.config.getString("test.specific-config") should ===("yes")

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -23,13 +23,13 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
       system.name should ===("ActorTestKitSpec")
     }
 
-    "generate a default name & ActorSystemSetup from the provided actor" in {
+    "generate a test kit from the provided actor" in {
       val config = ConfigFactory.parseString("test.specific-config = yes")
       val system = ActorSystem(ActorTestKitGuardian.testKitGuardian, "TestActor", config)
       val testkit2 = ActorTestKit(system)
       try {
-        testkit2.system.name should ===("TestActor")
-        testkit2.system.settings.config.getString("test.specific-config") should ===("yes")
+        testkit2.internalSystem should ===(system)
+        testkit2.system should ===(system)
       } finally testkit2.shutdownTestKit()
     }
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -366,7 +366,7 @@ class ClusterReceptionistSpec extends AnyWordSpec with Matchers with LogCapturin
           val PingKey.Listing(entries) = msg.last
           entries should have size 1
           val ref = entries.head
-          val service3RemotePath = RootActorPath(clusterNode3.selfMember.address) / "user" / "instance"
+          val service3RemotePath = RootActorPath(clusterNode3.selfMember.address) / "system" / "test" / "instance"
           ref.path should ===(service3RemotePath)
           ref.path.uid should ===(service3Uid)
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -366,7 +366,7 @@ class ClusterReceptionistSpec extends AnyWordSpec with Matchers with LogCapturin
           val PingKey.Listing(entries) = msg.last
           entries should have size 1
           val ref = entries.head
-          val service3RemotePath = RootActorPath(clusterNode3.selfMember.address) / "system" / "test" / "instance"
+          val service3RemotePath = RootActorPath(clusterNode3.selfMember.address) / "user" / "instance"
           ref.path should ===(service3RemotePath)
           ref.path.uid should ===(service3Uid)
 


### PR DESCRIPTION
for passing an ActorSystem or ActorSystemSetup (#27338).

Added an apply method that takes a akka.actor.typed.ActorSystem and generates a ActorTestKit.
Added an apply method that takes a string and akka.actor.setup.ActorSystemSetup and generates an ActorTestKit

Modified the internal ActorTestKit class to use an ActorSystemSetup instead of a config and updated the other apply methods to generate an ActorSystemSetup in place of the config.
This was an attempt to maintain compatability.

added the related test specs for the new apply methods and updated the apply methods that changed.